### PR TITLE
Open typeform in-app instead of native browser redirection.

### DIFF
--- a/widget/app.js
+++ b/widget/app.js
@@ -21,7 +21,7 @@
                     title: "TypeForm",
                     url: WidgetHome.data.content.url,
                     action: "linkToWeb",
-                    openIn: "_system",
+                    openIn: "_blank",
                   },
                   (err) => {
                     if (err) return console.error(err);


### PR DESCRIPTION
- Open typeform in-app instead of native browser redirection. (https://buildfire.atlassian.net/browse/PT-1265?atlOrigin=eyJpIjoiYzExMTAyYmQ4ODAxNDlkZjhiODYyNWFjMmRjYjE3MTIiLCJwIjoiaiJ9)